### PR TITLE
Removed margin from body element

### DIFF
--- a/streamlit_image_comparison/__init__.py
+++ b/streamlit_image_comparison/__init__.py
@@ -43,7 +43,7 @@ def image_comparison(
     img2: str,
     label1: str = "1",
     label2: str = "2",
-    width: int = 700,
+    width: int = 704,
     show_labels: bool = True,
     starting_position: int = 50,
     make_responsive: bool = True,
@@ -104,9 +104,10 @@ def image_comparison(
 
     # write html block
     htmlcode = f"""
+        <style>body {{ margin: unset; }}</style>
         {css_block}
         {js_block}
-        <div id="foo"style="height: {height}; width: {width or '%100'};"></div>
+        <div id="foo" style="height: {height}; width: {width or '100%'};"></div>
         <script>
         slider = new juxtapose.JXSlider('#foo',
             [


### PR DESCRIPTION
I have removed the margin from the body element with an extra style tag.

![image](https://user-images.githubusercontent.com/2125444/207098633-71e089e4-e1b1-4867-95b3-434e931e1bbe.png)

It might be worth noting that the default width (if the container size is not set to max) is 704 pixels. I also changed the default width to this. 

This allows the component to render nicely in the container in which it is created. :)